### PR TITLE
(index setup)^.adoc: Move intro to index

### DIFF
--- a/documentation/modules/ROOT/pages/01-setup.adoc
+++ b/documentation/modules/ROOT/pages/01-setup.adoc
@@ -1,24 +1,17 @@
 = Getting Started with Backstage
 include::_attributes.adoc[]
 
-[#introduction]
-== Introducing Backstage
-
-Screenshot of slides
-
-link to slides
-
 == Prerequisites
-You will need a GitHub account in order to follow along with this workshop.  Account activation is free and requires fewer than five minutes to complete.  If you do not have a github account, or are not prepared to authenticate using your existing account, please sign up for a new account now at github.com
+You need a GitHub account for this workshop to authenticate with the provided infrastructure and to store your source code. The account is free of charge and it takes about five minutes to register. If you do not have a GitHub account, or would like to use a dedicated account for this workshop, please create one now at <https://github.com>.
 
-Enter your github username in the onboarding doc then alert a lab assistant, and we will add you to the GitHub Org.  You will need to receive **and accept** an invite from our team before continuing on to the next step!
+Enter your github username in the onboarding doc and let an instructor know. We will add you to the GitHub Org for today's workshop. You must receive **and accept** an email invitation to our GitHub Org before continuing.
 
 [#cluster_access]
-== Cluster Access
+== OpenShift Cluster Access
 
-Check the onboarding doc for the latest cluster access urls and credentials ✅
+Check the onboarding doc for the latest cluster URL ✅
 
-Open the provided web console url in your browser to connect to the openshift web console. Choose the "Login with Github" option to proceed.
+Point a web browser to the OpenShift Web Console URL. Choose the *Login with Github* option.
 
 image::cluster_login.png[]
 image::cluster_auth.png[]
@@ -26,26 +19,22 @@ image::cluster_auth.png[]
 [#project_access]
 === Project Access
 
-This OpenShift cluster has been configured to automatically establish an initial project namespace for your work. 
-
-After logging in with Github, you should see a list of Projects with one result.  The project name should match your github id.
+Your user will have an OpenShift _Project_ for your exclusive use. Projects are a superset of the base Kubernetes _namespace_, and isolate resource names and access rights from other Projects on the cluster. Your OpenShift user and Project names both match the GitHub ID you used to log in.
 
 image::project_list.png[]
 
-Remember this project name!  You will need to enter it into several template inputs as your "Namespace" value in the next chapter.
+Remember your Project name. You'll specify it in Template forms as your "Namespace" value as you deploy components.
 
-Next, you will begin to populate this project namespace with new software components, generated via templates, as you build a three-tier GeoSpatial mapping demo application. 
-
-But first, the final step in this section involves connecting to our instance of Backstage.
+Next, you'll connect to Backstage and discover the starting point for developing your application. Once that's done, Backstage _Templates_ will help you generate software components as you build a three-tier GeoSpatial mapping demo application.
 
 [#backstage_access]
 == Logging in to Backstage
 
-Click on the app launcher link in the header menu and select "Backstage" to connect to your backstage instance.  
+Click on the app launcher link in the OpenShift Web Console header menu and select "Backstage". 
 
 image::console_backstage_link.png[]
 
-You will be prompted to authenticate.  Again, use the GitHub signin option.
+You will be prompted to authenticate. Use the GitHub login option.
 
 image::backstage_login.png[]
 
@@ -55,4 +44,4 @@ After authenticating via GitHub, Backstage will greet you with a cheerful "Welco
 
 image::backstage_welcome.png[]
 
-Now that we have established a project namespace on the cluster and a successful connection to backstage, you can start to create your workloads using Templates to populate the Service Catalog.
+Having established a Project on the OpenShift cluster and access to Backstage, you can start to build your app. First up: Instantiating Backstage _Templates_ to populate the Backstage Catalog.

--- a/documentation/modules/ROOT/pages/index.adoc
+++ b/documentation/modules/ROOT/pages/index.adoc
@@ -2,25 +2,32 @@
 :page-layout: home
 :!sectids:
 
-[.text-center.strong]
-== Internal Developer Platforms
+[#introduction]
+== An Internal Developer Platform (IDP)
 
-Live a day in the life of a happy developer in this hands-on journey through Red Hat’s latest incarnation of the Internal Developer Platform (IDP).
+Every team and every project evolves a tailored development environment. This collection of tools, services and configuration is often maintained by convention and transmitted by osmosis.
 
-Every team and every project evolves a tailored development environment. This collection of tools, services and configuration is usually maintained by convention and transmitted – you hope – by osmosis. Often it sprawls across each programmer’s laptop, and when details don’t match, problems happen.
+IDPs help teams curate, manage and replicate these environments. Backstage is an open source CNCF project for building developer platforms, and for encapsulating tools, services, documentation and best practices in “golden paths” to ease onboarding and daily development work.
 
-IDPs help teams curate, manage and replicate these environments. The platform your team stands atop is a product, and you can manage it like one. Backstage is an open source CNCF project for building developer platforms, and for encapsulating tools, services, documentation and best practices in “golden paths” to ease onboarding and daily development work.
+In this end-to-end developer experience, you’ll start on a golden path we’ve paved to show how Red Hat products center on the OpenShift Container Platform to supply a complete foundation for cloud-native development.
 
-In this end-to-end developer experience, you’ll start on a golden path we’ve laid out to show how Red Hat products center on the OpenShift Container Platform to supply a complete foundation for cloud-native development, and how Backstage tools let you mount your team’s scaffolding and best practices atop it.
+You will build and deploy a three-tier web application. You’ll be guided into OpenShift DevSpaces, a web-based Integrated Development Environment (IDE), to view and modify source code. OpenShift GitOps will automate the build, test and deploy cycle as you iterate your application with new features or fixes.
 
-Team members can immediately deploy the right tools and components to get to work. Presented with obvious choices for getting started, each participant will build and deploy a three-tier web application. Backstage will support you with immediate signposts to components, resources and relevant documentation.
+Backstage will support you from the start with signposts to components in a single place connecting the three key developer views: an IDE to code, pipelines to build, and orchestration to deploy your application.
 
-You’ll be guided right into OpenShift DevSpaces, a web-based Integrated Development Environment (IDE), to view and modify source code. OpenShift GitOps and build/test pipeline modules are available in the path, and you’ll use them to automate the build, test and deploy cycle as you iterate your application with new features and fixes.
+== Backstage Glossary
 
-In this hands-on session, you'll use headline Red Hat products and technologies and see the philosophy that ties them together to construct flexible foundations for cloud-native development.
+Enough Backstage to use it.
+
+* Create+ in left nav
+* _Template_ selection
+* Catalog: Entities
+* Deployed _Components_
 
 
+Screenshot of slides
 
+link to slides
 
 [.tiles.browse]
 == Workshop Outline


### PR DESCRIPTION
TODO: Complete *Backstage Glossary* intro section in `index.adoc`.

Implements reorg of intro material from page 01 to index page.
Rewrites/edits/condenses text in both pages and distills abstract.
Settles "we" vs "you" in favor of the second person.