### PR TITLE
01-setup: Add note about GH Org invite accept button

### DIFF
--- a/documentation/modules/ROOT/pages/01-setup.adoc
+++ b/documentation/modules/ROOT/pages/01-setup.adoc
@@ -5,7 +5,11 @@ include::_attributes.adoc[]
 == Prerequisites
 You need a GitHub account for this workshop to authenticate with the provided infrastructure and to store your source code. The account is free of charge and it takes about five minutes to register. If you do not have a GitHub account, or would like to use a dedicated account for this workshop, please create one now at <https://github.com>.
 
-Enter your github username in the onboarding doc and let an instructor know. We will add you to the GitHub Org for today's workshop. You must receive **and accept** an email invitation to our GitHub Org before continuing.
+Enter your github username in the onboarding doc and let an instructor know. We will add you to the GitHub Org for today's workshop. You must receive **and accept** an invitation to our GitHub Org before continuing.
+
+=== Where's my invite?
+
+Hate waiting and searching for email? When logged in to GitHub with an invited account, you'll see a button on the [Workshop GitHub Org home page][URL] to accept the invite and join the Org directly.
 
 [#cluster_access]
 == Accessing OpenShift


### PR DESCRIPTION
omits an actual URL for now because
1) multiple or single Org TBD
2) testers will be tempted to the literal value in the doc instead of one of the test orgs